### PR TITLE
ads.txt追加

### DIFF
--- a/web/ads.txt
+++ b/web/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-9504826327107353, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
ムーンカレンダーでads.txtを追加することになりました。
https://moon-calendar.jp/ads.txt でアクセスします。
https://trello.com/c/x9fo4B3N